### PR TITLE
Expand overlay bounding box

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,9 +193,12 @@
     }
 
     // Check if camera enters any overlay cubes to trigger sounds
+    // Expand the bounding box slightly so the trigger happens even if
+    // the camera is near the edge of the cube
     cubes.forEach(g => {
       if (!g.userData.triggered) {
         const box = new THREE.Box3().setFromObject(g.userData.overlay);
+        box.expandByScalar(0.05); // add ±0.05 units tolerance around the cube
         if (box.containsPoint(camera.position)) {
           playTone(g.userData.waveType);
           g.userData.triggered = true;


### PR DESCRIPTION
## Summary
- expand bounding box around overlay cubes by 0.05 units
- document the tolerance in code comments

## Testing
- `git show -n 1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68504a69d3a48332a2d5fe7dbad381fa