### PR TITLE
Display README content with psychedelic style

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,16 @@
       font-family: Arial, sans-serif;
       margin: 0;
       padding: 2rem;
-      background-color: #f6f6f6;
+      color: #fff;
+      background: radial-gradient(circle at 50% 50%, #ff00ff, #00ffff, #ffff00, #ff00ff);
+      background-size: 400% 400%;
+      animation: psychedelic-bg 20s linear infinite;
+    }
+
+    @keyframes psychedelic-bg {
+      0% { background-position: 0% 50%; }
+      50% { background-position: 100% 50%; }
+      100% { background-position: 0% 50%; }
     }
     header {
       text-align: center;
@@ -31,6 +40,20 @@
     <label><input type="checkbox" id="light-toggle"> Enable light estimation</label>
   </main>
       <div id="cube-container"></div>
+
+      <section id="readme">
+        <h2>Website</h2>
+        <p>This repository contains a minimal website that can be hosted using GitHub Pages.</p>
+        <h3>Getting Started</h3>
+        <ol>
+          <li>Clone the repository.</li>
+          <li>Enable GitHub Pages in the repository settings, using the main branch.</li>
+          <li>Visit the generated GitHub Pages URL to see the site. The page loads <code>three.js</code> modules directly from GitHub so it works even if CDNs like <strong>unpkg</strong> are blocked.</li>
+        </ol>
+        <p>The main content is in <code>index.html</code>. An <strong>Enter AR</strong> button is provided by <code>three.js</code> to start and exit the AR session. Use the <strong>Enable light estimation</strong> checkbox to choose whether light estimation will be used before entering AR.</p>
+        <h3>Requirements</h3>
+        <p>This site ships with <strong>three.js r128</strong> and requires a browser capable of WebXR's AR features (e.g. Chrome on Android). DOM overlay is used to display the HUD and performance stats while in AR. Make sure your browser supports this optional feature. For the best experience, use a mobile device that supports AR and ensure WebXR is enabled.</p>
+      </section>
 
     <script type="module">
       import * as THREE from 'https://raw.githubusercontent.com/mrdoob/three.js/r128/build/three.module.js';


### PR DESCRIPTION
## Summary
- added psychedelic animated gradient background
- embedded README instructions directly into the page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6852160c8770833280bcc2550da4ff9c