### PR TITLE
Add exit button and show AR button immediately

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,23 @@
       height: 400px;
       margin-top: 20px;
     }
+    #exit-ar {
+      position: absolute;
+      bottom: 20px;
+      right: 20px;
+      padding: 12px 6px;
+      border: 1px solid #fff;
+      border-radius: 4px;
+      background: rgba(0,0,0,0.1);
+      color: #fff;
+      font: normal 13px sans-serif;
+      opacity: 0.5;
+      cursor: pointer;
+      z-index: 1000;
+    }
+    #exit-ar:hover {
+      opacity: 1.0;
+    }
       /* GUI and stats are added via scripts */
   </style>
 </head>
@@ -39,6 +56,7 @@
     <p>This is a simple website served with GitHub Pages.</p>
   </main>
       <div id="cube-container"></div>
+      <button id="exit-ar">Exit AR</button>
 
       <section id="readme">
         <h2>Website</h2>
@@ -77,6 +95,12 @@
     renderer.setSize(container.clientWidth, container.clientHeight);
     renderer.xr.enabled = true;
     container.appendChild(renderer.domElement);
+
+    const exitButton = document.getElementById('exit-ar');
+    exitButton.addEventListener('click', () => {
+      const session = renderer.xr.getSession();
+      if (session) session.end();
+    });
 
     const stats = new Stats();
     overlayRoot.appendChild(stats.dom);

--- a/js/examples/jsm/webxr/ARButton.js
+++ b/js/examples/jsm/webxr/ARButton.js
@@ -152,14 +152,17 @@ class ARButton {
 
 		if ( 'xr' in navigator ) {
 
-			button.id = 'ARButton';
-			button.style.display = 'none';
+                       button.id = 'ARButton';
+                       stylizeElement( button );
+                       button.style.display = '';
+                       button.style.cursor = 'pointer';
+                       button.style.left = 'calc(50% - 50px)';
+                       button.style.width = '100px';
+                       button.textContent = 'START AR';
 
-			stylizeElement( button );
+                       navigator.xr.isSessionSupported( 'immersive-ar' ).then( function ( supported ) {
 
-			navigator.xr.isSessionSupported( 'immersive-ar' ).then( function ( supported ) {
-
-				supported ? showStartAR() : showARNotSupported();
+                               supported ? showStartAR() : showARNotSupported();
 
 			} ).catch( showARNotSupported );
 


### PR DESCRIPTION
## Summary
- ensure the WebXR button appears immediately by default
- add a persistent `Exit AR` button
- wire the button to end any running AR session

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68541eeb642c8332a60f2b6e37c65b80