### PR TITLE
Fix AR button when DOM overlay unsupported

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,8 @@
 
     // Add AR button to start the AR session with DOM overlay
     container.appendChild(ARButton.createButton(renderer, {
-      requiredFeatures: ['hit-test', 'dom-overlay'],
+      requiredFeatures: ['hit-test'],
+      optionalFeatures: ['dom-overlay'],
       domOverlay: { root: document.getElementById('overlay') }
     }));
 


### PR DESCRIPTION
## Summary
- show ARButton when DOM overlay is unavailable by making the feature optional

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856bb86931c8332a0ba739034acdaac